### PR TITLE
Escape javascript in SEED

### DIFF
--- a/app/views/adventures/show.html.erb
+++ b/app/views/adventures/show.html.erb
@@ -13,8 +13,8 @@
 <script>
   var SEED = {
     story: <%== @adventure.content.to_json %>,
-    title: "<%= @adventure.title %>",
-    description: "<%= @adventure.description %>",
-    theme: "<%= @adventure.theme.capitalize %>"
+    title: "<%= escape_javascript @adventure.title %>",
+    description: "<%= escape_javascript @adventure.description %>",
+    theme: "<%= escape_javascript @adventure.theme.capitalize %>"
   }
 </script>


### PR DESCRIPTION
Newline characters were breaking our seed because they weren't getting
replaced with \n.

Oops.