### PR TITLE
Fix some scroll edge cases

### DIFF
--- a/app/javascript/src/components/Player.css
+++ b/app/javascript/src/components/Player.css
@@ -3,6 +3,7 @@
  */
 
 .Player {
+  display: flex;
   height: 100%;
 }
 
@@ -20,8 +21,9 @@
   align-items: flex-start;
   display: flex;
   flex-direction: column;
-  height: 100%;
-  justify-content: center;
+  flex-grow: 1;
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .PlayerChoices {

--- a/app/javascript/src/components/Player.tsx
+++ b/app/javascript/src/components/Player.tsx
@@ -201,6 +201,10 @@ class Player extends React.Component<PlayerProps, PlayerState> {
     return this.state.currentModifiers.indexOf(modifier) !== -1
   }
 
+  private resetScroll() {
+    window.scrollTo(0, 0)
+  }
+
   private makeChoice(port: DefaultPortModel, event: Event) {
     event.preventDefault()
 
@@ -223,7 +227,7 @@ class Player extends React.Component<PlayerProps, PlayerState> {
       currentModifiers: modiifier
         ? [...state.currentModifiers, modiifier]
         : state.currentModifiers
-    }))
+    }), this.resetScroll)
   }
 
   private getRandom(nodes: string[]) {


### PR DESCRIPTION
Very long content could cause vertically centered text to cut off the
page. By using `auto` margins, we can get around this issue with
`justify-content: center`.

I also noticed that scroll wasn't updating for very long pages, so I
added a reset scroll handler.

Related to:

https://github.com/vigetlabs/storyboard/issues/49