### PR TITLE
Add notes to choice editor

### DIFF
--- a/app/javascript/src/Store.tsx
+++ b/app/javascript/src/Store.tsx
@@ -13,7 +13,8 @@ export interface ApplicationState {
 export interface MetaData {
   [id: string]: {
     title: string
-    text: string
+    text: string,
+    notes: string
   }
 }
 

--- a/app/javascript/src/components/Editor.tsx
+++ b/app/javascript/src/components/Editor.tsx
@@ -34,7 +34,7 @@ interface EditorProps {
 class Editor extends React.Component<EditorProps, EditorState> {
   engine: DiagramEngine
   model: DiagramModel
-  lastSavedState: ApplicationState
+  lastSavedState: string
 
   constructor(props: EditorProps) {
     super(props)
@@ -44,12 +44,11 @@ class Editor extends React.Component<EditorProps, EditorState> {
       selected: null,
       saving: false
     }
-
     this.engine = new DiagramEngine()
     this.engine.installDefaultFactories()
 
     this.updateStory(this.props.state.story)
-    this.lastSavedState = this.serialize()
+    this.lastSavedState = JSON.stringify(this.serialize())
   }
 
   async componentDidMount() {
@@ -323,7 +322,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
 
     const saveStart = Date.now()
     const newState = this.serialize()
-    const noChange = JSON.stringify(newState) === JSON.stringify(this.lastSavedState)
+    const noChange = JSON.stringify(newState) === this.lastSavedState
 
     // Don't save if nothing happened
     if (noChange && !opts.force) return
@@ -334,7 +333,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
       if (noChange) {
         // Do nothing, but let the UI change around
       } else {
-        this.lastSavedState = newState
+        this.lastSavedState = JSON.stringify(newState)
         await save(this.props.state.slug, newState)
       }
     } catch (error) {

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -21,18 +21,14 @@ interface SceneEditorProps {
 }
 
 class SceneEditor extends React.Component<SceneEditorProps> {
-  editor: React.RefObject<HTMLTextAreaElement> = React.createRef()
 
-  componentDidMount() {
-    this.install()
-  }
 
   render() {
     const { state, focus, requestPaint } = this.props
 
     // TODO: replace this. It doesn't matter much here but this breaks typechecking as get always returns `any`
     const text = get(state, `meta.${focus.id}.text`)
-
+    const notes = get(state, `meta.${focus.id}.notes`)
     return (
       <aside className="SceneEditor" onKeyUp={this.trapKeys}>
         <div className="SceneEditorField">
@@ -44,35 +40,40 @@ class SceneEditor extends React.Component<SceneEditorProps> {
           />
         </div>
 
-        <div className="SceneEditorField">
-          <label className="SceneEditorHeading" htmlFor="content">Content</label>
-          <textarea name="content" ref={this.editor} defaultValue={text} />
-        </div>
-
+        <SceneEditorTextAreaField
+          name="content"
+          title="Content"
+          defaultValue={text}
+          onChange={this.onChangeContent}
+        />
         <div className="SceneEditorField">
           <h3 className="SceneEditorHeading">Choices</h3>
 
           <ChoiceEditor focus={focus} requestPaint={requestPaint} />
+
+          {/* <SceneEditorTextAreaField
+          name="notes"
+          title="Notes"
+          defaultValue={notes}
+          onChange={this.onChangeNotes}
+        /> */}
         </div>
       </aside>
     )
   }
 
-  private install() {
-    if (this.editor.current) {
-      $R(this.editor.current, {
-        buttons: ['format', 'bold', 'italic', 'lists'],
-        callbacks: {
-          synced: (html: string) => this.onChange(html)
-        }
-      })
-    }
-  }
 
-  private onChange(html: string) {
+  private onChangeContent(html: string) {
+   // console.log(html.props)
     const { focus, state, updateState } = this.props
 
     updateState(set(state, `meta.${focus.id}.text`, html))
+  }
+
+  private onChangeNotes(html: string) {
+    const { focus, state, updateState } = this.props
+
+    updateState(set(state, `meta.${focus.id}.notes`, html))
   }
 
   private onNameChange = (event: React.FormEvent<HTMLInputElement>) => {
@@ -118,5 +119,35 @@ export default ({ focus, requestPaint, onClear }: ConsumerProps) => {
         />
       )}
     </StateConsumer>
+  )
+}
+
+type SceneEditorTextAreaFieldProps = {
+  name: string,
+  title: string,
+  defaultValue: string,
+  onChange: (arg0: string) => void
+}
+
+function SceneEditorTextAreaField({ name, title, defaultValue, onChange}: SceneEditorTextAreaFieldProps) {
+    let inputRef: React.RefObject<HTMLTextAreaElement> = React.createRef()
+  //editor: React.RefObject<HTMLTextAreaElement> = React.createRef()
+  
+  React.useEffect(() => {
+    if (inputRef.current) {
+      $R(inputRef.current, {
+        buttons: ['format', 'bold', 'italic', 'lists'],
+        callbacks: {
+          synced: (html: string) => onChange(html)
+        }
+      })
+    }
+  }, [inputRef.current])
+
+  return (
+    <div className="SceneEditorField">
+      <label className="SceneEditorHeading" htmlFor={name}>{title}</label>
+      <textarea name={name} ref={inputRef} defaultValue={defaultValue} />
+    </div>
   )
 }

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -53,7 +53,7 @@ class SceneEditor extends React.Component<SceneEditorProps> {
           <h3 className="SceneEditorHeading">Choices</h3>
 
           <ChoiceEditor focus={focus} requestPaint={requestPaint} />
-          </div>
+        </div>
 
         <SceneEditorTextAreaField
           name="notes"
@@ -68,7 +68,7 @@ class SceneEditor extends React.Component<SceneEditorProps> {
   }
 
 
-   private onChangeContent(html: string) {
+  private onChangeContent(html: string) {
     const { focus, state, updateState } = this.props
 
     updateState(set(state, `meta.${focus.id}.text`, html))

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -46,7 +46,7 @@ class SceneEditor extends React.Component<SceneEditorProps> {
           defaultValue={text}
           placeholderText=""
           instructionalText=""
-          onChange={this.onChangeContent.bind(this)}
+          onChange={this.onChangeContent}
 
         />
         <div className="SceneEditorField">
@@ -61,20 +61,20 @@ class SceneEditor extends React.Component<SceneEditorProps> {
           placeholderText="Enter any editor-only notes you have here"
           instructionalText="This box is for adding comments, new ideas, or general notes for this scene. These notes are not visible to the user."
           defaultValue={notes}
-          onChange={this.onChangeNotes.bind(this)}
+          onChange={this.onChangeNotes}
         />
       </aside>
     )
   }
 
 
-  private onChangeContent(html: string) {
+  onChangeContent = (html: string) => {
     const { focus, state, updateState } = this.props
 
     updateState(set(state, `meta.${focus.id}.text`, html))
   }
 
-  private onChangeNotes(html: string) {
+  onChangeNotes = (html: string) => {
     const { focus, state, updateState } = this.props
 
     updateState(set(state, `meta.${focus.id}.notes`, html))

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -29,7 +29,6 @@ class SceneEditor extends React.Component<SceneEditorProps> {
     // TODO: replace this. It doesn't matter much here but this breaks typechecking as get always returns `any`
     const text = get(state, `meta.${focus.id}.text`)
     const notes = get(state, `meta.${focus.id}.notes`)
-    console.log(text)
     return (
       <aside className="SceneEditor" onKeyUp={this.trapKeys}>
         <div className="SceneEditorField">
@@ -45,8 +44,9 @@ class SceneEditor extends React.Component<SceneEditorProps> {
           name="content"
           title="Content"
           defaultValue={text}
+          placeholderText=""
+          instructionalText=""
           onChange={this.onChangeContent.bind(this)}
-          // onChange={this.onChangeContent}
 
         />
         <div className="SceneEditorField">
@@ -57,7 +57,9 @@ class SceneEditor extends React.Component<SceneEditorProps> {
 
         <SceneEditorTextAreaField
           name="notes"
-          title="Notes"
+          title="Editor Notes"
+          placeholderText="Enter any editor-only notes you have here"
+          instructionalText="This box is for adding comments, new ideas, or general notes for this scene. These notes are not visible to the user."
           defaultValue={notes}
           onChange={this.onChangeNotes.bind(this)}
         />
@@ -67,7 +69,6 @@ class SceneEditor extends React.Component<SceneEditorProps> {
 
 
    private onChangeContent(html: string) {
-   // console.log(html.props)
     const { focus, state, updateState } = this.props
 
     updateState(set(state, `meta.${focus.id}.text`, html))
@@ -129,16 +130,20 @@ type SceneEditorTextAreaFieldProps = {
   name: string,
   title: string,
   defaultValue: string,
+  placeholderText: string,
+  instructionalText: string,
   onChange: (arg0: string) => void
 }
 
-function SceneEditorTextAreaField({ name, title, defaultValue, onChange}: SceneEditorTextAreaFieldProps) {
-    let inputRef: React.RefObject<HTMLTextAreaElement> = React.createRef()
-  //editor: React.RefObject<HTMLTextAreaElement> = React.createRef()
+/**
+ * 
+ * New abstracted-out way of render react components for the text areas, since the Content and Notes areas are very similar
+ */
+function SceneEditorTextAreaField({ name, title, defaultValue, placeholderText, instructionalText, onChange}: SceneEditorTextAreaFieldProps) {
+  let inputRef: React.RefObject<HTMLTextAreaElement> = React.createRef()
 
   
   React.useEffect(() => {
-    console.log(inputRef);
     if (inputRef.current) {
       $R(inputRef.current, {
         buttons: ['format', 'bold', 'italic', 'lists'],
@@ -152,7 +157,8 @@ function SceneEditorTextAreaField({ name, title, defaultValue, onChange}: SceneE
   return (
     <div className="SceneEditorField">
       <label className="SceneEditorHeading" htmlFor={name}>{title}</label>
-      <textarea name={name} ref={inputRef} defaultValue={defaultValue} />
+      <textarea placeholder={placeholderText} name={name} ref={inputRef} defaultValue={defaultValue} />
+      <p>{instructionalText}</p>
     </div>
   )
 }

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -29,6 +29,7 @@ class SceneEditor extends React.Component<SceneEditorProps> {
     // TODO: replace this. It doesn't matter much here but this breaks typechecking as get always returns `any`
     const text = get(state, `meta.${focus.id}.text`)
     const notes = get(state, `meta.${focus.id}.notes`)
+    console.log(text)
     return (
       <aside className="SceneEditor" onKeyUp={this.trapKeys}>
         <div className="SceneEditorField">
@@ -44,26 +45,28 @@ class SceneEditor extends React.Component<SceneEditorProps> {
           name="content"
           title="Content"
           defaultValue={text}
-          onChange={this.onChangeContent}
+          onChange={this.onChangeContent.bind(this)}
+          // onChange={this.onChangeContent}
+
         />
         <div className="SceneEditorField">
           <h3 className="SceneEditorHeading">Choices</h3>
 
           <ChoiceEditor focus={focus} requestPaint={requestPaint} />
+          </div>
 
-          {/* <SceneEditorTextAreaField
+        <SceneEditorTextAreaField
           name="notes"
           title="Notes"
           defaultValue={notes}
-          onChange={this.onChangeNotes}
-        /> */}
-        </div>
+          onChange={this.onChangeNotes.bind(this)}
+        />
       </aside>
     )
   }
 
 
-  private onChangeContent(html: string) {
+   private onChangeContent(html: string) {
    // console.log(html.props)
     const { focus, state, updateState } = this.props
 
@@ -132,8 +135,10 @@ type SceneEditorTextAreaFieldProps = {
 function SceneEditorTextAreaField({ name, title, defaultValue, onChange}: SceneEditorTextAreaFieldProps) {
     let inputRef: React.RefObject<HTMLTextAreaElement> = React.createRef()
   //editor: React.RefObject<HTMLTextAreaElement> = React.createRef()
+
   
   React.useEffect(() => {
+    console.log(inputRef);
     if (inputRef.current) {
       $R(inputRef.current, {
         buttons: ['format', 'bold', 'italic', 'lists'],


### PR DESCRIPTION
Fixes #67 

This PR adds an Editor Notes textarea to the Editor view of a story. Instead of directly copying the Content textarea code, we decided to abstract it out to function component `SceneEditorTextAreaField`.

While developing, we found an issue with saving certain fields on the editor due to an idempotence issue with how previous versions were being compared to figure out if the save actually needed to fire. This PR addresses that issue as well.  