### PR TITLE
Fix Clone Type Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 /node_modules
 yarn-debug.log*
 .yarn-integrity
+.vscode/

--- a/app/javascript/src/clone.ts
+++ b/app/javascript/src/clone.ts
@@ -1,3 +1,3 @@
-export function clone(obj: any): any {
+export function clone<T>(obj: T): T {
   return JSON.parse(JSON.stringify(obj))
 }

--- a/app/javascript/src/components/PortEditor.tsx
+++ b/app/javascript/src/components/PortEditor.tsx
@@ -292,7 +292,7 @@ class PortEditor extends React.Component<PortEditorProps & PortEditorStateProps,
 
   setShowIfStatValue = (index: number, e: React.FocusEvent<HTMLInputElement>) => {
     let newShowIfStats = clone(this.state.thisPortMeta.showIfStats || [])
-    newShowIfStats[index].value = e.target.value
+    newShowIfStats[index].value = parseInt(e.target.value, 0)
 
     this.state.thisPortMeta.showIfStats = newShowIfStats
     this.savePortMeta()
@@ -352,6 +352,7 @@ class PortEditor extends React.Component<PortEditorProps & PortEditorStateProps,
 
   toggleItemChange = (index: number, e: React.ChangeEvent<HTMLSelectElement>) => {
     e.preventDefault()
+    if (e.target.value !== "add" && e.target.value !== "remove") return
 
     let newItemChanges = clone(this.state.thisPortMeta.itemChanges || [])
     newItemChanges[index].action = e.target.value
@@ -367,7 +368,7 @@ class PortEditor extends React.Component<PortEditorProps & PortEditorStateProps,
     e.preventDefault()
 
     let newStatChanges = clone(this.state.thisPortMeta.statChanges || [])
-    newStatChanges.push({ name: "", value: undefined, action: "+" })
+    newStatChanges.push({ name: "", value: 0, action: "+" })
 
     this.state.thisPortMeta.statChanges = newStatChanges
     this.savePortMeta()
@@ -391,7 +392,7 @@ class PortEditor extends React.Component<PortEditorProps & PortEditorStateProps,
   }
   setStatValue = (index: number, e: React.FocusEvent<HTMLInputElement>) => {
     let newStatChanges = clone(this.state.thisPortMeta.statChanges || [])
-    newStatChanges[index].value = e.target.value
+    newStatChanges[index].value = parseInt(e.target.value, 0)
 
     this.state.thisPortMeta.statChanges = newStatChanges
     this.savePortMeta()
@@ -399,6 +400,7 @@ class PortEditor extends React.Component<PortEditorProps & PortEditorStateProps,
 
   toggleStatChanges = (index: number, e: React.ChangeEvent<HTMLSelectElement>) => {
     e.preventDefault()
+    if (e.target.value !== "+" && e.target.value !== "-") return
 
     let newStatChanges = clone(this.state.thisPortMeta.statChanges || [])
     newStatChanges[index].action = e.target.value


### PR DESCRIPTION
We are deep cloning objects by using `JSON.parse(JSON.stringify(obj))` which works, but returns an any.   Changing this method to a generic revealed a number of existing type errors. Some aren't real.  But a couple definitely are, and it looks like there's been some defensive coding other places in the app to protect against unchecked values leaking into the app.

I've seen a number of places where we are casting undefined to Number on a field that is not optional and should always be a number. eg `Number(thing.that['is'].aNumber)`

@DanielSBrown This is based on your modifier branch but can be switched to master once that's merged.
