### PR TITLE
[Editor View] Mark a scene as completed

### DIFF
--- a/app/javascript/src/components/Editor.tsx
+++ b/app/javascript/src/components/Editor.tsx
@@ -539,7 +539,10 @@ class Editor extends React.Component<EditorProps, EditorState> {
       let inPortsWithLinks = []
       let outPortsWithLinks = []
       let outPorts = []
+<<<<<<< HEAD
       let isFinal = meta ? meta.isFinal : false
+=======
+>>>>>>> 5de1905... Update styles a bit and remove uneccessary ternaries. Might want a fed to look at some of this styling -- can't seem to get the label text to be INSIDE the label
 
       for (let key in node.ports) {
         let port = node.ports[key] as DefaultPortModel
@@ -562,7 +565,11 @@ class Editor extends React.Component<EditorProps, EditorState> {
       } else if (!inPortsWithLinks.length && !outPortsWithLinks.length) {
         // orphan: has no [in/out ports with links]
         node.color = '#ffeb3b'
+<<<<<<< HEAD
       } else if (isFinal) {
+=======
+      } else if (meta.isFinal) {
+>>>>>>> 5de1905... Update styles a bit and remove uneccessary ternaries. Might want a fed to look at some of this styling -- can't seem to get the label text to be INSIDE the label
         // has been marked as complete
         node.color = '#808080'
       } else if (!outPorts.length) {

--- a/app/javascript/src/components/Editor.tsx
+++ b/app/javascript/src/components/Editor.tsx
@@ -539,10 +539,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
       let inPortsWithLinks = []
       let outPortsWithLinks = []
       let outPorts = []
-<<<<<<< HEAD
       let isFinal = meta ? meta.isFinal : false
-=======
->>>>>>> 5de1905... Update styles a bit and remove uneccessary ternaries. Might want a fed to look at some of this styling -- can't seem to get the label text to be INSIDE the label
 
       for (let key in node.ports) {
         let port = node.ports[key] as DefaultPortModel

--- a/app/javascript/src/components/Editor.tsx
+++ b/app/javascript/src/components/Editor.tsx
@@ -539,6 +539,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
       let inPortsWithLinks = []
       let outPortsWithLinks = []
       let outPorts = []
+      let isFinal = meta ? meta.isFinal : false
 
       for (let key in node.ports) {
         let port = node.ports[key] as DefaultPortModel
@@ -561,7 +562,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
       } else if (!inPortsWithLinks.length && !outPortsWithLinks.length) {
         // orphan: has no [in/out ports with links]
         node.color = '#ffeb3b'
-      } else if (meta.isFinal) {
+      } else if (isFinal) {
         // has been marked as complete
         node.color = '#808080'
       } else if (!outPorts.length) {

--- a/app/javascript/src/components/Editor.tsx
+++ b/app/javascript/src/components/Editor.tsx
@@ -565,11 +565,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
       } else if (!inPortsWithLinks.length && !outPortsWithLinks.length) {
         // orphan: has no [in/out ports with links]
         node.color = '#ffeb3b'
-<<<<<<< HEAD
       } else if (isFinal) {
-=======
-      } else if (meta.isFinal) {
->>>>>>> 5de1905... Update styles a bit and remove uneccessary ternaries. Might want a fed to look at some of this styling -- can't seem to get the label text to be INSIDE the label
         // has been marked as complete
         node.color = '#808080'
       } else if (!outPorts.length) {

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -139,6 +139,33 @@ export default ({ focus, requestPaint, onClear }: ConsumerProps) => {
 
 
 
+type SceneEditorSettingsFieldsProps = {
+  name: string,
+  checkboxText: string,
+  checkboxDefault: boolean,
+  onChange: () => void
+}
+
+function SceneEditorSettingsFields({
+  name,
+  checkboxText,
+  checkboxDefault,
+  onChange
+}: SceneEditorSettingsFieldsProps) {
+
+  return (
+    <div className="SceneEditorField">
+      <label className="SceneEditorHeading" htmlFor={name}>
+        {name}
+      </label>
+    <div>
+      Mark this scene as final?
+      <input type="checkbox" defaultChecked={checkboxDefault} onClick={onChange}/>
+    </div>
+  </div>
+  )
+}
+
 /**
  *
  * New abstracted-out way of render react components for the text areas, since the Content and Notes areas are very similar

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -88,9 +88,6 @@ class SceneEditor extends React.Component<SceneEditorProps> {
     updateState(set(state, `meta.${focus.id}.notes`, html))
   }
 
-
-
-
   private onNameChange = (event: React.FormEvent<HTMLInputElement>) => {
     this.props.focus.name = event.currentTarget.value
     this.props.requestPaint()

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -155,11 +155,10 @@ function SceneEditorSettingsFields({
       <label className="SceneEditorHeading" htmlFor={name}>
         {name}
       </label>
-      <div>
-        Mark this scene as final?
-        <input type="checkbox" defaultChecked={checkboxDefault} onClick={onChange}/>
+      <div className="checkboxes">
+        <label htmlFor="finalCheckbox"><input type="checkbox" id="finalCheckbox" defaultChecked={checkboxDefault} onClick={onChange} /> <span>Mark this scene as final?</span></label>
       </div>
-  </div>
+    </div>
   )
 }
 

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -88,17 +88,6 @@ class SceneEditor extends React.Component<SceneEditorProps> {
     updateState(set(state, `meta.${focus.id}.notes`, html))
   }
 
-<<<<<<< HEAD
-=======
-  onChangeFinal = () => {
-    const { focus, state, updateState } = this.props
-    const isFinal = get(state, `meta.${focus.id}.isFinal`)
-
-    updateState(set(state, `meta.${focus.id}.isFinal`, !isFinal))
-  }
-
-
->>>>>>> 5de1905... Update styles a bit and remove uneccessary ternaries. Might want a fed to look at some of this styling -- can't seem to get the label text to be INSIDE the label
   private onNameChange = (event: React.FormEvent<HTMLInputElement>) => {
     this.props.focus.name = event.currentTarget.value
     this.props.requestPaint()

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -155,10 +155,10 @@ function SceneEditorSettingsFields({
       <label className="SceneEditorHeading" htmlFor={name}>
         {name}
       </label>
-    <div>
-      Mark this scene as final?
-      <input type="checkbox" defaultChecked={checkboxDefault} onClick={onChange}/>
-    </div>
+      <div>
+        Mark this scene as final?
+        <input type="checkbox" defaultChecked={checkboxDefault} onClick={onChange}/>
+      </div>
   </div>
   )
 }

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -143,25 +143,6 @@ type SceneEditorSettingsFieldsProps = {
   onChange: () => void
 }
 
-function SceneEditorSettingsFields({
-  name,
-  checkboxText,
-  checkboxDefault,
-  onChange
-}: SceneEditorSettingsFieldsProps) {
-
-  return (
-    <div className="SceneEditorField">
-      <label className="SceneEditorHeading">
-        {name}
-      </label>
-      <div className="checkboxes">
-      <label htmlFor="finalCheckbox"><input type="checkbox" id="finalCheckbox" defaultChecked={checkboxDefault} onClick={onChange} />
-        Mark this scene as final?</label>
-      </div>
-    </div>
-  )
-}
 
 /**
  *

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -88,6 +88,17 @@ class SceneEditor extends React.Component<SceneEditorProps> {
     updateState(set(state, `meta.${focus.id}.notes`, html))
   }
 
+<<<<<<< HEAD
+=======
+  onChangeFinal = () => {
+    const { focus, state, updateState } = this.props
+    const isFinal = get(state, `meta.${focus.id}.isFinal`)
+
+    updateState(set(state, `meta.${focus.id}.isFinal`, !isFinal))
+  }
+
+
+>>>>>>> 5de1905... Update styles a bit and remove uneccessary ternaries. Might want a fed to look at some of this styling -- can't seem to get the label text to be INSIDE the label
   private onNameChange = (event: React.FormEvent<HTMLInputElement>) => {
     this.props.focus.name = event.currentTarget.value
     this.props.requestPaint()
@@ -152,11 +163,12 @@ function SceneEditorSettingsFields({
 
   return (
     <div className="SceneEditorField">
-      <label className="SceneEditorHeading" htmlFor={name}>
+      <label className="SceneEditorHeading">
         {name}
       </label>
       <div className="checkboxes">
-        <label htmlFor="finalCheckbox"><input type="checkbox" id="finalCheckbox" defaultChecked={checkboxDefault} onClick={onChange} /> <span>Mark this scene as final?</span></label>
+      <label htmlFor="finalCheckbox"><input type="checkbox" id="finalCheckbox" defaultChecked={checkboxDefault} onClick={onChange} />
+        Mark this scene as final?</label>
       </div>
     </div>
   )


### PR DESCRIPTION
Addresses #89 

![image](https://user-images.githubusercontent.com/16651533/78179152-b9a2e700-742e-11ea-92fd-e1204ec985c6.png)

There is a new settings panel on the editor pane to mark a scene as final. This is primarily for complex stories, in which the Editor is working on many different scenes, and a scene that doesn't have any links/ports yet may not necessarily be a final scene. This is a way for the editor to differentiate between final scenes and paths that just haven't been completed.

Some more work needs to go into the UI of the Settings pane, but I just like making PRs early to get feedback early.

Right now, final scenes are only a different color, whereas the ticket mentioned maybe having an icon on the scene. I will look into that now 

