### PR TITLE
Url hash progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 yarn-debug.log*
 .yarn-integrity
 .vscode/
+
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,3 @@
 yarn-debug.log*
 .yarn-integrity
 .vscode/
-
-package-lock.json

--- a/app/javascript/src/components/Editor.tsx
+++ b/app/javascript/src/components/Editor.tsx
@@ -72,16 +72,6 @@ class Editor extends React.Component<EditorProps, EditorState> {
     if (JSON.stringify(story) !== JSON.stringify(newStory)) {
       this.updateStory(newStory)
       this.forceUpdate()
-    }
-
-    // track history
-    let currentState = clone(this.serialize())
-    let pastState = this.past[this.past.length - 1]
-
-    if (JSON.stringify(currentState) != JSON.stringify(pastState)) {
-      this.past.push(currentState)
-      this.future = []
-      console.log('update')
     } else {
       console.log('nothing new')
     }

--- a/app/javascript/src/components/Editor.tsx
+++ b/app/javascript/src/components/Editor.tsx
@@ -73,6 +73,18 @@ class Editor extends React.Component<EditorProps, EditorState> {
       this.updateStory(newStory)
       this.forceUpdate()
     }
+
+    // track history
+    let currentState = clone(this.serialize())
+    let pastState = this.past[this.past.length - 1]
+
+    if (JSON.stringify(currentState) != JSON.stringify(pastState)) {
+      this.past.push(currentState)
+      this.future = []
+      console.log('update')
+    } else {
+      console.log('nothing new')
+    }
   }
 
   updateStory(story: any) {

--- a/app/javascript/src/components/Player.tsx
+++ b/app/javascript/src/components/Player.tsx
@@ -69,13 +69,24 @@ class Player extends React.Component<PlayerProps, PlayerState> {
   }
 
   componentDidMount() {
-    this.setState({
-      focus: this.findStartKey()
-    })
+    if (window.location.hash == '') {
+      this.setState({
+        focus: this.findStartKey()
+      })
+    } else {
+      let currentState = JSON.parse(
+        decodeURI(window.location.hash.replace(/^\#/, ''))
+      )
+      this.setState(currentState)
+    }
   }
 
   start = () => {
     this.setState({ started: true })
+  }
+
+  componentDidUpdate() {
+    window.location.hash = JSON.stringify(this.state)
   }
 
   render() {

--- a/app/javascript/src/components/Player.tsx
+++ b/app/javascript/src/components/Player.tsx
@@ -73,7 +73,7 @@ class Player extends React.Component<PlayerProps, PlayerState> {
   }
 
   componentDidMount() {
-    if (window.location.hash == '') {
+    if (window.location.hash == '' || window.location.hash == null) {
       this.setState({
         focus: this.findStartKey()
       })

--- a/app/javascript/src/components/Player.tsx
+++ b/app/javascript/src/components/Player.tsx
@@ -23,6 +23,8 @@ import { PlayerInvalid } from './PlayerInvalid'
 import { PlayerEnd, PlayerDeadEnd } from './PlayerEnd'
 import { clone } from '../clone'
 
+var CryptoJS = require('crypto-js')
+
 interface PlayerProps {
   description: string
   meta: MetaData
@@ -50,6 +52,8 @@ class Player extends React.Component<PlayerProps, PlayerState> {
   engine: DiagramEngine
   model: DiagramModel
 
+  private passphrase = 'labrats'
+
   state: PlayerState = {
     started: false,
     currentItems: [],
@@ -74,9 +78,11 @@ class Player extends React.Component<PlayerProps, PlayerState> {
         focus: this.findStartKey()
       })
     } else {
-      let currentState = JSON.parse(
-        decodeURI(window.location.hash.replace(/^\#/, ''))
+      let bytes = CryptoJS.AES.decrypt(
+        window.location.hash.replace(/^\#/, ''),
+        this.passphrase
       )
+      let currentState = JSON.parse(bytes.toString(CryptoJS.enc.Utf8))
       this.setState(currentState)
     }
   }
@@ -86,7 +92,10 @@ class Player extends React.Component<PlayerProps, PlayerState> {
   }
 
   componentDidUpdate() {
-    window.location.hash = JSON.stringify(this.state)
+    window.location.hash = CryptoJS.AES.encrypt(
+      JSON.stringify(this.state),
+      this.passphrase
+    ).toString()
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/node": "^12.6.9",
     "@types/react": "^16.4.18",
     "@types/react-dom": "^16.0.9",
+    "crypto-js": "^4.0.0",
     "lodash": "^4.17.13",
     "prop-types": "^15.6.2",
     "react": "^16.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2050,6 +2050,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
+  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
+
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz#dfdefd3254bf8a82027993674ccf35483bfcb3c5"


### PR DESCRIPTION
# Summary
Fixes #32. Adds a url hash which tracks progress through a story so that users can visit the url and pop in to a story mid-progress. 

## Logic
- In `componentDidUpdate()` (i.e. every time there's a state change) takes `this.state`, encrypts it and sets it as a url hash
- In `componentDidMount()`, if the url has a hash value present, decrypt it and set it as the currentState instead of starting at the beginning of the story

## Comments
I'm storing the passphrase for the encryption in a private member variable of the `Player` class. Not sure if that's the best way to hide it from the user...