### PR TITLE
Add support for ctrl+Y redo keyboard shortcut

### DIFF
--- a/app/javascript/src/components/Editor.tsx
+++ b/app/javascript/src/components/Editor.tsx
@@ -71,7 +71,10 @@ class Editor extends React.Component<EditorProps, EditorState> {
     })
 
     document.onkeydown = e => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key == 'z') {
+      if (
+        ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key == 'z') ||
+        ((e.metaKey || e.ctrlKey) && e.key == 'y')
+      ) {
         this.redo()
         e.preventDefault()
       } else if ((e.metaKey || e.ctrlKey) && e.key == 'z') {


### PR DESCRIPTION
`this.redo()` is now triggered by the `ctrl+Y` keyboard shortcut as well as `cmd+shift+Z`