### PR TITLE
Get JS specs running in Docker

### DIFF
--- a/.docker-config/Dockerfile
+++ b/.docker-config/Dockerfile
@@ -5,7 +5,25 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -qq -y build-essential libpq-dev \
-    postgresql-client nodejs yarn && \
+    postgresql-client nodejs yarn \
+    wget xvfb unzip && \
     rm -rf /var/lib/apt/lists/*
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | \
+    apt-key add - && \
+    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> \
+    /etc/apt/sources.list.d/google.list && \
+    apt-get update -y && \
+    apt-get install -y google-chrome-stable && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CHROMEDRIVER_VERSION 2.19
+ENV CHROMEDRIVER_DIR /chromedriver
+
+RUN mkdir $CHROMEDRIVER_DIR && \
+  wget -q --continue -P $CHROMEDRIVER_DIR "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" && \
+  unzip $CHROMEDRIVER_DIR/chromedriver* -d $CHROMEDRIVER_DIR
+
+ENV PATH $CHROMEDRIVER_DIR:$PATH
 
 WORKDIR /usr/src/app

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,7 +13,18 @@ require 'support/factory_bot.rb'
 
 include Warden::Test::Helpers
 
-Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.register_driver :chrome_headless do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :chrome_headless
 
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Adapted from:

* https://gist.github.com/varyonic/dea40abcf3dd891d204ef235c6e8dd79
* https://lamphanqg.github.io/2019/01/20/dockerized-capybara.html

I'm not sure if that update to `rails_helper.rb` is going to break JS specs running locally (i.e. not in Docker). If it does, a fix could be:

1. Add an `environment:` variable to `docker-compose.yml` like "DOCKER_CHROMEDRIVER=true" or something
2. Add a check to `rails_helper.rb` to look for that variable and choose the capybara driver accordingly