### PR TITLE
[#168] Collapse audio section by default

### DIFF
--- a/app/javascript/src/components/ReactVoiceRecorder.css
+++ b/app/javascript/src/components/ReactVoiceRecorder.css
@@ -235,3 +235,7 @@
   position: absolute;
   transform: translate(-50%)
 }
+
+.recorderSection {
+  width: 100%;
+}

--- a/app/javascript/src/components/SceneEditor.css
+++ b/app/javascript/src/components/SceneEditor.css
@@ -92,6 +92,7 @@
   padding: 9px 14px 6px;
 }
 
+.audioButton,
 .settingsButton {
   border: none;
   background: none;

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -34,6 +34,7 @@ interface AudioDetails {
 
 interface SceneEditorState {
   audioDetails: AudioDetails
+  audioOpen: boolean
 }
 
 interface SceneEditorProps {
@@ -53,6 +54,9 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
   constructor(props: SceneEditorProps) {
     super(props)
 
+    const { state, focus } = props
+    const audio = get(state, `meta.${focus.id}.audio`)
+
     this.state = {
       audioDetails: {
         url: null,
@@ -63,12 +67,14 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
           m: 0,
           s: 0
         }
-      }
+      },
+      audioOpen: !!audio
     }
   }
 
   render() {
     const { state, focus, requestPaint, updateDiagram } = this.props
+    const { audioOpen } = this.state
 
     // TODO: replace this. It doesn't matter much here but this breaks typechecking as get always returns `any`
     const text = get(state, `meta.${focus.id}.text`)
@@ -103,7 +109,7 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
         )
       } else {
         return (
-          <div>
+          <div className="recorderSection">
             <input type="file" accept="audio/*" onChange={this.onAudioChange} />
             <h3 className="recorderHeader">Record your own audio!</h3>
             <ReactVoiceRecorder.Recorder
@@ -154,8 +160,20 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
         </div>
 
         <div className="SceneEditorField">
-          <h3 className="SceneEditorHeading">Audio</h3>
-          {renderAudioSection()}
+          <label className="SceneEditorHeading">
+            Audio
+
+            <button className="audioButton" onClick={this.audioButtonClick}>
+              {audioOpen ? 'v' : '>'}
+            </button>
+          </label>
+          <section>
+            {audioOpen && (
+              <>
+                {renderAudioSection()}
+              </>
+            )}
+          </section>
         </div>
 
         <SceneEditorTextAreaField
@@ -175,6 +193,10 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
         <br/><br/>
       </aside>
     )
+  }
+
+  audioButtonClick = () => {
+    this.setState(prevState => ({ audioOpen: !prevState.audioOpen }))
   }
 
   handleAudioStop(data: AudioDetails) {


### PR DESCRIPTION
Issue #168 

This PR just makes it so the audio section in the scene editor is collapsed by default since it takes up a decent bit of space and the majority of our users probably will not be using it.

![Screen Shot 2021-11-09 at 12 00 22 PM](https://user-images.githubusercontent.com/25255820/140970049-ce5cf134-9953-4e47-ba99-1d73d26ff395.png)
![Screen Shot 2021-11-09 at 12 00 36 PM](https://user-images.githubusercontent.com/25255820/140970052-9631a0b9-d54d-48c6-831c-f0cbf6cf49cd.png)
![Screen Shot 2021-11-09 at 12 00 51 PM](https://user-images.githubusercontent.com/25255820/140970055-720065ca-0305-4965-a743-b4f5ba2f0df8.png)

