### PR TITLE
[#173] Fix issue with blank content in final scene

### DIFF
--- a/app/javascript/src/components/Player.tsx
+++ b/app/javascript/src/components/Player.tsx
@@ -646,16 +646,18 @@ class Player extends React.Component<PlayerProps, PlayerState> {
   }
 
   private translate(text: string): string {
-    this.prepareHandlebars()
-    var expressionVariables = {} as any
-    [text, expressionVariables] = this.prepareTextForTranslation(text)
-    try {
-      const template = Handlebars.compile(text)
-      text = template(expressionVariables)
-    } catch (error) {
-      alert("There was a problem translating your template.")
+    if (text) {
+      this.prepareHandlebars()
+      var expressionVariables = {} as any
+      [text, expressionVariables] = this.prepareTextForTranslation(text)
+      try {
+        const template = Handlebars.compile(text)
+        text = template(expressionVariables)
+      } catch (error) {
+        alert("There was a problem translating your template.")
+      }
+      text = this.repairTextAfterTranslation(text)
     }
-    text = this.repairTextAfterTranslation(text)
     return text
   }
 


### PR DESCRIPTION
Issue #173 

This fixes a bug where if a scene is final and the content is blank, it is throwing the templating error. This is because we were checking if `meta` was null and if it was then setting the text to an empty string, which works for most scenes because `meta` will typically be null without content, but for the final scene it is not because `meta` includes the `isFinal` field. In theory, this would've also been a problem if anyone included an image or audio with their scene but did not fill out content, because those would also be cases in which `meta` is not null but `meta.text` is.