### PR TITLE
[#189] Prevent 'nymphomania' feedback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rails', '~> 5.2.1'
 gem 'uglifier'
 gem 'webpacker', '~> 4.0.7'
 gem 'sentry-raven'
-gem 'pointless_feedback', '~> 4.0.6'
+gem 'pointless_feedback', '~> 4.1.4'
 gem 'stat_board', '~> 1.1.0'
 gem 'administrate', '~> 0.13.0'
 gem "dragonfly"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,10 @@ GEM
       momentjs-rails (~> 2.8)
       sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
+    airrecord (1.0.9)
+      faraday (>= 0.10, < 3.0)
+      faraday-net_http_persistent
+      net-http-persistent
     arel (9.0.0)
     autoprefixer-rails (9.7.6)
       execjs
@@ -105,6 +109,7 @@ GEM
     chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    connection_pool (2.2.5)
     crass (1.0.5)
     database_cleaner (0.9.1)
     datetime_picker_rails (0.0.7)
@@ -125,7 +130,7 @@ GEM
       dragonfly (~> 1.0)
       fog-aws
     erubi (1.8.0)
-    ethon (0.11.0)
+    ethon (0.12.0)
       ffi (>= 1.3.0)
     excon (0.85.0)
     execjs (2.7.0)
@@ -136,6 +141,7 @@ GEM
       railties (>= 4.2.0)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
+    faraday-net_http_persistent (1.2.0)
     ffi (1.9.25)
     fog-aws (3.10.0)
       fog-core (~> 2.1)
@@ -200,6 +206,8 @@ GEM
     msgpack (1.2.4)
     multi_json (1.15.0)
     multipart-post (2.0.0)
+    net-http-persistent (4.0.1)
+      connection_pool (~> 2.2)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-sftp (3.0.0)
@@ -212,7 +220,8 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     pg (1.1.3)
-    pointless_feedback (4.0.6)
+    pointless_feedback (4.1.4)
+      airrecord (~> 1.0)
       jquery-rails (>= 4.0)
       rails (>= 4.0)
       typhoeus (~> 0.7, >= 0.7.3)
@@ -363,7 +372,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mimemagic!
   pg (>= 0.18, < 2.0)
-  pointless_feedback (~> 4.0.6)
+  pointless_feedback (~> 4.1.4)
   pry-rails
   puma (~> 3.12)
   rails (~> 5.2.1)

--- a/config/initializers/pointless_feedback.rb
+++ b/config/initializers/pointless_feedback.rb
@@ -15,4 +15,8 @@ PointlessFeedback.setup do |config|
   ]
   config.google_captcha_site_key   = "6Lcx6pQUAAAAANoXFts8_nsPSoNikCW6p80aCIL_"
   config.google_captcha_secret_key = "6Lcx6pQUAAAAALoO68Z-f5vxBehQZLkxZkQvwkGw"
+
+  # Configure the words that will prevent an email from being sent if they are
+  # contained in the description
+  config.invalid_words = ['nymphomania']
 end


### PR DESCRIPTION
#### Addresses #189 

- Prevents feedback with `nymphomania` in the description by upgrading `pointless_feedback` to the version that allows prevention of invalid words and adding `nymphomania` to the list.