### PR TITLE
[#188] Only show content in logs on deletion of story

### DIFF
--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -112,6 +112,7 @@ class AdventuresController < ApplicationController
   end
 
   def destroy
+    Rails.logger.info @adventure.content
     @adventure.destroy
     if current_user
       redirect_to my_adventures_url, notice: 'Adventure was successfully destroyed.'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :content]


### PR DESCRIPTION
#### Addresses #188 

- Filter `content` parameter from logs.
- Set production logs to use `info` so passwords and content are not shown there.
- Log story content upon deletion of the story.