### PR TITLE
[#186] Prevent creation of stories without an account

### DIFF
--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -46,6 +46,11 @@ class AdventuresController < ApplicationController
   end
 
   def new
+    if !current_user
+      flash[:alert] = "You must be logged in to create a story."
+      return redirect_to new_user_session_path
+    end
+
     @adventure = Adventure.new
   end
 

--- a/spec/features/adventure_spec.rb
+++ b/spec/features/adventure_spec.rb
@@ -238,10 +238,11 @@ describe "Adventures" do
       end
     end
 
-    it "lets you create a story" do
+    it "redirects you to the log in page if you attempt to create a story" do
       visit "/"
       click_on "Create a Story"
-      expect(page).to have_content("What's your title?")
+      expect(page).to have_content("You must be logged in to create a story.")
+      expect(page.current_path).to eq('/users/sign_in')
     end
 
     it "does not let you view /mine" do


### PR DESCRIPTION
#### Addresses #186 

- If a user attempts to create a story before logging in, redirect them to the log in page.