### PR TITLE
[#204] Add a checkbox to scenes to hide title

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ rake db:create db:migrate db:seed
 
 
 # Docker
+
 ```
 docker-compose build
 docker-compose up
@@ -23,3 +24,5 @@ docker-compose up
 docker-compose exec app rake db:migrate
 docker-compose exec app rake db:seed
 ```
+
+**Note**: If you're building these images on Apple Silicon (M1/M2 Mac), you can use the environment variable `DOCKER_DEFAULT_PLATFORM=linux/amd64` to avoid platform-related build issues when running `docker-compose build`.

--- a/app/javascript/src/Store.tsx
+++ b/app/javascript/src/Store.tsx
@@ -16,6 +16,8 @@ export interface MetaData {
     text: string
     notes: string
     isFinal: boolean
+    hideTitle: boolean
+    // showTitle: boolean
     image: string
     audio: string
   }

--- a/app/javascript/src/Store.tsx
+++ b/app/javascript/src/Store.tsx
@@ -17,7 +17,6 @@ export interface MetaData {
     notes: string
     isFinal: boolean
     hideTitle: boolean
-    // showTitle: boolean
     image: string
     audio: string
   }

--- a/app/javascript/src/components/Player.tsx
+++ b/app/javascript/src/components/Player.tsx
@@ -168,7 +168,6 @@ class Player extends React.Component<PlayerProps, PlayerState> {
       return <PlayerInvalid />
     }
 
-    // let meta = this.props.meta[focus] || { text: '', image: '', showTitle: true }
     let meta = this.props.meta[focus] || { text: '', image: '', hideTitle: false }
     let translatedText = this.translate(meta.text)
     let choices = this.ports(node)
@@ -177,6 +176,7 @@ class Player extends React.Component<PlayerProps, PlayerState> {
       return (
         <PlayerEnd
           title={node.name}
+          hideTitle={meta.hideTitle}
           body={translatedText}
           image={meta.image}
           audio={meta.audio}
@@ -213,7 +213,6 @@ class Player extends React.Component<PlayerProps, PlayerState> {
       <main className="PlayerScene">
         {this.renderBackButton()}
         <div className="PlayerForeground">
-          {/*meta.showTitle && <h1 className="PlayerSceneTitle">{node.name}</h1>*/}
           {!meta.hideTitle && <h1 className="PlayerSceneTitle">{node.name}</h1>}
 
           <div className="PlayerSceneContent">

--- a/app/javascript/src/components/Player.tsx
+++ b/app/javascript/src/components/Player.tsx
@@ -168,7 +168,8 @@ class Player extends React.Component<PlayerProps, PlayerState> {
       return <PlayerInvalid />
     }
 
-    let meta = this.props.meta[focus] || { text: '', image: '' }
+    // let meta = this.props.meta[focus] || { text: '', image: '', showTitle: true }
+    let meta = this.props.meta[focus] || { text: '', image: '', hideTitle: false }
     let translatedText = this.translate(meta.text)
     let choices = this.ports(node)
 
@@ -212,7 +213,8 @@ class Player extends React.Component<PlayerProps, PlayerState> {
       <main className="PlayerScene">
         {this.renderBackButton()}
         <div className="PlayerForeground">
-          <h1 className="PlayerSceneTitle">{node.name}</h1>
+          {/*meta.showTitle && <h1 className="PlayerSceneTitle">{node.name}</h1>*/}
+          {!meta.hideTitle && <h1 className="PlayerSceneTitle">{node.name}</h1>}
 
           <div className="PlayerSceneContent">
             {renderImage()}

--- a/app/javascript/src/components/PlayerEnd.tsx
+++ b/app/javascript/src/components/PlayerEnd.tsx
@@ -8,12 +8,13 @@ interface Props {
   body: string
   image: string
   audio: string
+  hideTitle: boolean
   onReplay: () => void
   onGoBack: () => void
   showSource: boolean
 }
 
-export const PlayerEnd: React.SFC<Props> = ({ title, body, image, audio, onReplay, onGoBack, showSource }) => {
+export const PlayerEnd: React.SFC<Props> = ({ title, body, image, audio, hideTitle, onReplay, onGoBack, showSource }) => {
   const renderImage = () => {
     if (image) {
       return <img src={image} alt='' width='400' />
@@ -60,7 +61,7 @@ export const PlayerEnd: React.SFC<Props> = ({ title, body, image, audio, onRepla
       </a>
       {renderSourceButton()}
       <div className="PlayerForeground">
-        <h1 className="PlayerEndTitle">{title}</h1>
+        <h1 className="PlayerEndTitle">{!hideTitle && title}</h1>
         <div className="PlayerEndContent">
           {renderImage()}
           {renderAudioSection()}
@@ -90,6 +91,7 @@ export const PlayerDeadEnd: React.SFC<DeadEndProps> = ({ onReplay, onGoBack, sho
       body="That choice wasn't tied to a new scene. You should fix that. Try replaying the story."
       image=''
       audio=''
+      hideTitle
       onReplay={onReplay}
       onGoBack={onGoBack}
       showSource={showSource}

--- a/app/javascript/src/components/SceneEditor.css
+++ b/app/javascript/src/components/SceneEditor.css
@@ -31,7 +31,7 @@
   letter-spacing: 0.05em;
 }
 
-.SceneEditorField input,
+.SceneEditorField input:not(.checkbox),
 .SceneEditorField textarea {
   border-radius: 3px;
   box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.19);
@@ -114,4 +114,8 @@
   height: auto;
   vertical-align: middle;
   width: auto;
+}
+
+.checkbox {
+  float: right;
 }

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -80,12 +80,9 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
     const text = get(state, `meta.${focus.id}.text`)
     const notes = get(state, `meta.${focus.id}.notes`)
     const isFinal = get(state, `meta.${focus.id}.isFinal`)
-    // const showTitle = get(state, `meta.${focus.id}.showTitle`)
     const hideTitle = get(state, `meta.${focus.id}.hideTitle`)
     const image = get(state, `meta.${focus.id}.image`)
     const audio = get(state, `meta.${focus.id}.audio`)
-
-    console.log(hideTitle)
 
     const renderImageSection = () => {
       if (image) {
@@ -142,21 +139,6 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
             onChange={this.onNameChange}
           />
         </div>
-        {
-          /*
-          <div className="SceneEditorField">
-            <label className="SceneEditorHeading" htmlFor="showTitle">
-              Show Scene Title
-            </label>
-            <input
-              name="showTitle"
-              defaultChecked={showTitle}
-              onChange={this.onChangeShowTitle}
-              type="checkbox"
-            />
-          </div>
-          */
-        }
 
         <div className="SceneEditorField">
           <label className="SceneEditorHeading" htmlFor="hideTitle">
@@ -169,7 +151,6 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
             type="checkbox"
           />
         </div>
-        
 
         <SceneEditorTextAreaField
           name="content"
@@ -274,14 +255,6 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
 
     updateState(set(state, `meta.${focus.id}.notes`, html))
   }
-
-  /*
-  onChangeShowTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { focus, state, updateState } = this.props
-
-    updateState(set(state, `meta.${focus.id}.showTitle`, event.target.checked))
-  }
-  */
 
   onChangeHideTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { focus, state, updateState } = this.props

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -80,8 +80,12 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
     const text = get(state, `meta.${focus.id}.text`)
     const notes = get(state, `meta.${focus.id}.notes`)
     const isFinal = get(state, `meta.${focus.id}.isFinal`)
+    // const showTitle = get(state, `meta.${focus.id}.showTitle`)
+    const hideTitle = get(state, `meta.${focus.id}.hideTitle`)
     const image = get(state, `meta.${focus.id}.image`)
     const audio = get(state, `meta.${focus.id}.audio`)
+
+    console.log(hideTitle)
 
     const renderImageSection = () => {
       if (image) {
@@ -138,6 +142,34 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
             onChange={this.onNameChange}
           />
         </div>
+        {
+          /*
+          <div className="SceneEditorField">
+            <label className="SceneEditorHeading" htmlFor="showTitle">
+              Show Scene Title
+            </label>
+            <input
+              name="showTitle"
+              defaultChecked={showTitle}
+              onChange={this.onChangeShowTitle}
+              type="checkbox"
+            />
+          </div>
+          */
+        }
+
+        <div className="SceneEditorField">
+          <label className="SceneEditorHeading" htmlFor="hideTitle">
+            Hide Scene Title
+          </label>
+          <input 
+            name="hideTitle"
+            defaultChecked={hideTitle}
+            onChange={this.onChangeHideTitle}
+            type="checkbox"
+          />
+        </div>
+        
 
         <SceneEditorTextAreaField
           name="content"
@@ -241,6 +273,20 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
     const { focus, state, updateState } = this.props
 
     updateState(set(state, `meta.${focus.id}.notes`, html))
+  }
+
+  /*
+  onChangeShowTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { focus, state, updateState } = this.props
+
+    updateState(set(state, `meta.${focus.id}.showTitle`, event.target.checked))
+  }
+  */
+
+  onChangeHideTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { focus, state, updateState } = this.props
+
+    updateState(set(state, `meta.${focus.id}.hideTitle`, event.target.checked))
   }
 
   onImageChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/app/javascript/src/components/SceneEditor.tsx
+++ b/app/javascript/src/components/SceneEditor.tsx
@@ -143,13 +143,14 @@ class SceneEditor extends React.Component<SceneEditorProps, SceneEditorState> {
         <div className="SceneEditorField">
           <label className="SceneEditorHeading" htmlFor="hideTitle">
             Hide Scene Title
+            <input
+              className="checkbox"
+              name="hideTitle"
+              defaultChecked={hideTitle}
+              onChange={this.onChangeHideTitle}
+              type="checkbox"
+            />
           </label>
-          <input 
-            name="hideTitle"
-            defaultChecked={hideTitle}
-            onChange={this.onChangeHideTitle}
-            type="checkbox"
-          />
         </div>
 
         <SceneEditorTextAreaField


### PR DESCRIPTION
### Issues
- #204 

### What?
- Adds hide title checkbox in scene editor
- Hides titles when checkboxes are checked

### Images
Checkbox
<img width="278" alt="Screen Shot 2022-09-30 at 5 55 36 PM" src="https://user-images.githubusercontent.com/95887913/193361490-d74fdd6f-2320-47f8-9b2a-3bcfa724e965.png">
Regular scene
<img width="816" alt="Screen Shot 2022-09-30 at 5 56 08 PM" src="https://user-images.githubusercontent.com/95887913/193361528-37933983-b289-4a30-b16b-d2a6bf72dee0.png">
End scene
<img width="783" alt="Screen Shot 2022-09-30 at 5 56 34 PM" src="https://user-images.githubusercontent.com/95887913/193361559-9c47e8dd-a14c-494c-85a1-5a348ac8d546.png">

