### PR TITLE
[#228] Tweak looping functionality to make it more obvious for users

### DIFF
--- a/app/javascript/src/Store.tsx
+++ b/app/javascript/src/Store.tsx
@@ -34,6 +34,7 @@ export interface PortMetaContent {
   isTimer: boolean
   hideChoice: boolean
   timeoutSeconds: number
+  isLoop: boolean
 }
 
 export interface ShowIfItem {

--- a/app/javascript/src/components/Editor.tsx
+++ b/app/javascript/src/components/Editor.tsx
@@ -830,7 +830,10 @@ class Editor extends React.Component<EditorProps, EditorState> {
         let sourcePort = link.sourcePort as DefaultPortModel
         let targetPort = link.targetPort as DefaultPortModel
 
-        if (sourcePort.in && !targetPort.in) {
+        if (sourcePort.getNode().getID() == targetPort.getNode().getID()) {
+          // port loops back to same node, prefer users use the loop functionality
+          this.model.links[key].remove()
+        } else if (sourcePort.in && !targetPort.in) {
           // link was dragged from target to source, switch the ports
           this.model.links[key].remove()
 

--- a/app/javascript/src/components/Player.tsx
+++ b/app/javascript/src/components/Player.tsx
@@ -629,6 +629,8 @@ class Player extends React.Component<PlayerProps, PlayerState> {
       get(this.props.portMeta as any, `${port.id}.itemChanges`) || []
     const statChanges: StatChange[] =
       get(this.props.portMeta as any, `${port.id}.statChanges`) || []
+    const isLoop: boolean =
+      get(this.props.portMeta as any, `${port.id}.isLoop`) || false
 
     let newItems = clone(this.state.currentItems)
     let newStats = clone(this.state.currentStats)
@@ -702,6 +704,13 @@ class Player extends React.Component<PlayerProps, PlayerState> {
         targetNodes.push(link.targetPort.parent.id)
       }
     }
+
+    // If port is set to be a loop port, add the current node
+    // to the potential targets
+    if (isLoop && this.state.focus) {
+      targetNodes.push(this.state.focus)
+    }
+
     let nextNode = this.getRandom(targetNodes) || 'empty'
 
     let newHistory = clone(this.state.history)
@@ -720,11 +729,6 @@ class Player extends React.Component<PlayerProps, PlayerState> {
       },
       this.resetScroll
     )
-  }
-
-  private strip(html: string) {
-    var doc = new DOMParser().parseFromString(html, 'text/html')
-    return doc.body.textContent || ''
   }
 
   private translate(text: string): string {

--- a/app/javascript/src/components/PortEditor.tsx
+++ b/app/javascript/src/components/PortEditor.tsx
@@ -73,7 +73,7 @@ class PortEditor extends React.Component<
     const {
       selectedTab,
       optionsOpen,
-      thisPortMeta: { showIfItems, showIfStats, itemChanges, statChanges, isTimer, hideChoice, timeoutSeconds }
+      thisPortMeta: { showIfItems, showIfStats, itemChanges, statChanges, isTimer, hideChoice, timeoutSeconds, isLoop }
     } = this.state
 
     return (
@@ -132,6 +132,16 @@ class PortEditor extends React.Component<
                   onClick={() => this.setSelectedTab('timer')}
                 >
                   Timer
+                </button>
+                <button
+                  className={
+                    selectedTab === 'loop'
+                      ? 'pe-active-tab'
+                      : 'pe-inactive-tab'
+                  }
+                  onClick={() => this.setSelectedTab('loop')}
+                >
+                    Loop
                 </button>
               </div>
 
@@ -501,6 +511,28 @@ class PortEditor extends React.Component<
                   </ul>
                 </div>
               )}
+
+              {selectedTab === 'loop' && (
+                <div className="flexDiv">
+                  <PortEditorHeader>Set Up Loop</PortEditorHeader>
+
+                  <ul className="pe-list">
+                    <li>
+                      <div>
+                        <input
+                          id={`is-loop-${port.id}`}
+                          type="checkbox"
+                          checked={isLoop}
+                          onChange={this.toggleLoop.bind(this)}
+                        />
+                        <label htmlFor={`is-loop-${port.id}`} className="checkbox-label">
+                          Loop Back to Same Scene?
+                        </label>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              )}
             </>
           )}
         </section>
@@ -533,6 +565,14 @@ class PortEditor extends React.Component<
 
   setTimeoutSeconds = (e: React.FocusEvent<HTMLInputElement>) => {
     this.state.thisPortMeta.timeoutSeconds = parseInt(e.target.value, 0)
+    this.savePortMeta()
+  }
+
+  /**
+   * Loop
+   */
+  toggleLoop = (e: React.MouseEvent) => {
+    this.state.thisPortMeta.isLoop = !this.state.thisPortMeta.isLoop
     this.savePortMeta()
   }
 

--- a/app/javascript/src/components/TutorialPage.tsx
+++ b/app/javascript/src/components/TutorialPage.tsx
@@ -111,7 +111,14 @@ const pages: TutorialPageContent[] = [
     image: require('../images/tutorial/timers.gif')
   },
   {
-    title: '#12 - Advanced - Using Formatting',
+    title: '#12 - Advanced - Using Looping',
+    text: [
+      "Using looping allows you to send the player back to the same scene you were just in, but with all the stat and item changes applied."
+    ],
+    image: require('../images/tutorial/looping.gif')
+  },
+  {
+    title: '#13 - Advanced - Using Formatting',
     text: [
       'Formatting allows you to customize the scene content depending on your items and stats.',
       'When someone is playing the game created by the below example, we will show the player their \'Energy\' and \'Speed\' values and then will tell them that they have the \'Key\' if the \'Key\' is present.'
@@ -121,19 +128,19 @@ const pages: TutorialPageContent[] = [
     link: 'Get additional help.'
   },
   {
-    title: "#13 - Advanced - Copying and Pasting",
+    title: "#14 - Advanced - Copying and Pasting",
     text: [
       'If you want certain sections of your story to also be in another one of your stories, you can easily copy and paste that section of the story with either our \'Copy\' and \'Paste\' buttons or your typical keyboard shortcuts.',
-      'In order to select the section of your story to copy, you have several options. You can just click on a singular scene you want to copy, you can hold the Shift key and drag your mouse over the seciton you want to copy, or you can hold the Shift key while clicking the scenes you wish to copy.'
+      'In order to select the section of your story to copy, you have several options. You can just click on a singular scene you want to copy, you can hold the Shift key and drag your mouse over the section you want to copy, or you can hold the Shift key while clicking the scenes you wish to copy.'
     ],
     image: require('../images/tutorial/copy-paste.gif')
   },
   {
-    title: '#14 - Time to Play!',
+    title: '#15 - Time to Play!',
     text: ['Press “Play” to read your story and get a shareable link.']
   },
   {
-    title: '#15 - Disclaimer',
+    title: '#16 - Disclaimer',
     text: [
       "This project was primarily built in a weekend, so you may encounter some quirks along the way. If something doesn't look right, saving your story and refreshing the page might do the trick. If saving isn't working, you can try copying and pasting your story into a new story as a last resort.",
       'And of course, feel free to drop us a note in our feedback form (available from the footer on the homepage).',


### PR DESCRIPTION
## Issues

#228 

## What this PR does

- Adds an option to the loop back to the same scene in the choice editor.
- Removes the ability to drag a link from the scene's choice to the same scene's in port.
- Add a tutorial page explaining this functionality.
- Remove unused `strip` method from `Player.tsx`.
- Fix spelling mistake on another tutorial page.

## Screenshots

![Screen Shot 2023-02-03 at 1 33 18 PM](https://user-images.githubusercontent.com/25255820/216683497-b2520bf2-7bb4-4f63-be86-5320d4765a7a.png)

*NOTE: I originally tried utilizing the existing functionality that allowed a user to connect a scene to itself but decided to get rid of that and go with this instead because the link ends up rendering behind the scene itself so you cannot tell that it is there and there is no way to select the link in order to delete it. Also, attempts to actually make the link loop out around the scene all ended up looking fairly terrible and I did not see a good way to fix that problem.*