### PR TITLE
[#230] Fix bug where stats/showIfs cannot be set to zero

### DIFF
--- a/app/javascript/src/components/Player.tsx
+++ b/app/javascript/src/components/Player.tsx
@@ -659,8 +659,8 @@ class Player extends React.Component<PlayerProps, PlayerState> {
         if (change.action === '-') {
           startValue = change.value * -1
         } else if (change.action === '?') {
-          const min = change.min ? change.min : 1
-          const max = change.max ? change.max : 10
+          const min = change.min != undefined ? change.min : 1
+          const max = change.max != undefined ? change.max : 10
 
           startValue = Math.floor(Math.random() * (max - min + 1) + min);
         } else {
@@ -684,8 +684,8 @@ class Player extends React.Component<PlayerProps, PlayerState> {
           // Subtract it from the total
           newStats[indexOfStat].value = Number(change.value)
         } else if (change.action === '?') {
-          const min = change.min ? Number(change.min) : 1
-          const max = change.max ? Number(change.max) : 10
+          const min = change.min != undefined ? Number(change.min) : 1
+          const max = change.max != undefined ? Number(change.max) : 10
 
           newStats[indexOfStat].value = Math.floor(Math.random() * (max - min + 1) + min);
         }

--- a/app/javascript/src/components/PortEditor.tsx
+++ b/app/javascript/src/components/PortEditor.tsx
@@ -249,7 +249,7 @@ class PortEditor extends React.Component<
                                 id={`stat-value-${statChange.name}`}
                                 onBlur={this.setStatValue.bind(this, i)}
                                 defaultValue={
-                                  statChange.value
+                                  statChange.value != undefined
                                     ? statChange.value.toString()
                                     : ''
                                 }
@@ -269,7 +269,7 @@ class PortEditor extends React.Component<
                                   onBlur={this.setStatMin.bind(this, i)}
                                   placeholder="Min"
                                   defaultValue={
-                                    statChange.min
+                                    statChange.min != undefined
                                       ? statChange.min.toString()
                                       : ''
                                   }
@@ -287,7 +287,7 @@ class PortEditor extends React.Component<
                                   onBlur={this.setStatMax.bind(this, i)}
                                   placeholder="Max"
                                   defaultValue={
-                                    statChange.max
+                                    statChange.max != undefined
                                       ? statChange.max.toString()
                                       : ''
                                   }
@@ -434,7 +434,7 @@ class PortEditor extends React.Component<
                               id={`show-if-stat-value-${deSpace(showIf.name)}`}
                               onBlur={this.setShowIfStatValue.bind(this, i)}
                               defaultValue={
-                                showIf.value ? showIf.value.toString() : ''
+                                showIf.value != undefined ? showIf.value.toString() : ''
                               }
                             />
                           </div>
@@ -493,7 +493,7 @@ class PortEditor extends React.Component<
                           id="timeout-seconds"
                           onBlur={this.setTimeoutSeconds.bind(this)}
                           defaultValue={
-                            timeoutSeconds ? timeoutSeconds.toString() : ''
+                            timeoutSeconds != undefined ? timeoutSeconds.toString() : ''
                           }
                         />
                       </div>


### PR DESCRIPTION
## Issue(s)

#230 

## What this PR does

- When port meta number fields are set to 0, respect the 0 instead of pretending like it is undefined.