### PR TITLE
[#238] Add duplicate story button

### DIFF
--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -142,7 +142,7 @@ class AdventuresController < ApplicationController
     duplicated_adventure.title = "Copy of #{@adventure.title}"
     duplicated_adventure.save
 
-    redirect_to [:edit, duplicated_adventure], notice: "Adventure was successfully copied."
+    redirect_to [:edit, duplicated_adventure]
   end
 
   private

--- a/app/controllers/adventures_controller.rb
+++ b/app/controllers/adventures_controller.rb
@@ -1,5 +1,5 @@
 class AdventuresController < ApplicationController
-  before_action :set_adventure, only: [:show, :edit, :update, :destroy, :details, :source, :offline, :authenticate]
+  before_action :set_adventure, only: [:show, :edit, :update, :destroy, :details, :source, :offline, :authenticate, :duplicate]
   before_action :check_authentication, only: [:show]
 
   def index
@@ -130,6 +130,19 @@ class AdventuresController < ApplicationController
     if current_user.try(:is_admin?)
       send_data(AdventureExport.export, filename: "storyboard_adventures_#{Date.current.strftime("%x").gsub("/", "-")}.csv")
     end
+  end
+
+  def duplicate
+    if !@adventure.editable_by?(current_user)
+      flash[:alert] = "You can't modify that Adventure"
+      return redirect_to root_url
+    end
+
+    duplicated_adventure = @adventure.dup
+    duplicated_adventure.title = "Copy of #{@adventure.title}"
+    duplicated_adventure.save
+
+    redirect_to [:edit, duplicated_adventure], notice: "Adventure was successfully copied."
   end
 
   private

--- a/app/views/adventures/details.html.erb
+++ b/app/views/adventures/details.html.erb
@@ -3,6 +3,8 @@
 
   <%= render "shared/adventure_form", is_update: true, correct_user: @adventure.user && @adventure.user == current_user %>
 
+  <%= link_to "Duplicate Story", duplicate_adventure_path(@adventure), method: :post, class: "SlantButton" %>
+
   <footer class="AccountFormFooter">
     <%= link_to 'Back to Edit', [:edit, @adventure] %>
     <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     get "source", on: :member
     get "offline", on: :member
     post "authenticate", on: :member
+    post "duplicate", on: :member
     get "mine", on: :collection, as: :my
     get "archived", on: :collection, as: :my_archived
     get "csv", on: :collection


### PR DESCRIPTION
#238 

- Adds a new endpoint that duplicates an existing story and redirects you to the newly duplicated story.
- Adds a button to story's details page that calls the duplicate endpoint.